### PR TITLE
Add Slab property in Add Floors operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.txt
 *.sublime-project
 *.sublime-workspace
+*.vscode

--- a/core/floor/floor.py
+++ b/core/floor/floor.py
@@ -21,12 +21,13 @@ class Floor:
 
         if cls.validate(bm):
             cls.add_floor_facemaps()
-            if any([f for f in bm.faces if f.select]):
-                create_floors(bm, None, prop)
+            selected_faces = [f for f in bm.faces if f.select]
+            if selected_faces:
+                create_floors(bm, selected_faces, prop)
                 select(bm.faces, False)
             else:
-                edges = [e for e in bm.edges if e.is_boundary]
-                create_floors(bm, edges, prop)
+                all_faces = [f for f in bm.faces]
+                create_floors(bm, all_faces, prop)
             bmesh.update_edit_mesh(me, True)
             return {"FINISHED"}
         return {"CANCELLED"}

--- a/core/floor/floor_props.py
+++ b/core/floor/floor_props.py
@@ -1,5 +1,5 @@
 import bpy
-from bpy.props import IntProperty, FloatProperty
+from bpy.props import IntProperty, FloatProperty, BoolProperty
 
 
 class FloorProperty(bpy.types.PropertyGroup):
@@ -15,9 +15,15 @@ class FloorProperty(bpy.types.PropertyGroup):
         description="Height of each floor",
     )
 
+    add_slab: BoolProperty(
+        name="Add Slab",
+        default=True,
+        description="Add slab between each floor",
+    )
+
     slab_thickness: FloatProperty(
         name="Slab Thickness",
-        min=0.0,
+        min=0.01,
         max=1000.0,
         default=0.2,
         description="Thickness of each slab",
@@ -39,5 +45,7 @@ class FloorProperty(bpy.types.PropertyGroup):
         col.prop(self, "floor_height")
 
         col = box.column(align=True)
-        col.prop(self, "slab_thickness")
-        col.prop(self, "slab_outset")
+        col.prop(self, "add_slab")
+        if self.add_slab == True:
+            col.prop(self, "slab_thickness")
+            col.prop(self, "slab_outset")

--- a/core/floor/floor_props.py
+++ b/core/floor/floor_props.py
@@ -46,6 +46,6 @@ class FloorProperty(bpy.types.PropertyGroup):
 
         col = box.column(align=True)
         col.prop(self, "add_slab")
-        if self.add_slab == True:
+        if self.add_slab:
             col.prop(self, "slab_thickness")
             col.prop(self, "slab_outset")

--- a/utils/util_mesh.py
+++ b/utils/util_mesh.py
@@ -229,16 +229,6 @@ def edge_split_offset(bm, edges, verts, offset, connect_verts=False):
     return new_verts
 
 
-def boundary_edges_from_faces(faces):
-    """ Find all edges that bound the given faces
-    """
-    edges = list({e for f in faces for e in f.edges})
-    is_boundary = (
-        lambda e: len({f for f in e.link_faces if f in faces}) == 1
-    )
-    return [e for e in edges if is_boundary(e)]
-
-
 def arc_edge(bm, edge, resolution, height, offset, function="SPHERE"):
     """ Subdivide the given edge and offset vertices to form an arc
     """

--- a/utils/util_mesh.py
+++ b/utils/util_mesh.py
@@ -229,15 +229,14 @@ def edge_split_offset(bm, edges, verts, offset, connect_verts=False):
     return new_verts
 
 
-def boundary_edges_from_face_selection(bm):
-    """ Find all edges that bound the current selected faces
+def boundary_edges_from_faces(faces):
+    """ Find all edges that bound the given faces
     """
-    selected_faces = [f for f in bm.faces if f.select]
-    all_edges = list({e for f in selected_faces for e in f.edges})
-    edge_is_boundary = (
-        lambda e: len({f for f in e.link_faces if f in selected_faces}) == 1
+    edges = list({e for f in faces for e in f.edges})
+    is_boundary = (
+        lambda e: len({f for f in e.link_faces if f in faces}) == 1
     )
-    return [e for e in all_edges if edge_is_boundary(e)]
+    return [e for e in edges if is_boundary(e)]
 
 
 def arc_edge(bm, edge, resolution, height, offset, function="SPHERE"):


### PR DESCRIPTION
Provide a tick box for `Add Slab` when using `Add Floors`.
<img width="596" alt="Screenshot 2020-03-10 at 11 08 53 PM" src="https://user-images.githubusercontent.com/11018027/76342263-57b9fa80-6324-11ea-9c30-d3e7cdf08688.png">
<img width="596" alt="Screenshot 2020-03-10 at 11 09 06 PM" src="https://user-images.githubusercontent.com/11018027/76342275-5b4d8180-6324-11ea-87d6-ac92d5361b75.png">

fixes #26 

Other changes:
1. Now `Add Floor` operation always deletes faces which will not be visible.
2. Slab outset is now uniform.
3. Top is now not converted to a n-gon, instead it maintains original geometry.