### PR TITLE
Compatibility: default mesh

### DIFF
--- a/core/balcony/balcony.py
+++ b/core/balcony/balcony.py
@@ -1,12 +1,13 @@
 import bmesh
 
 from .balcony_types import create_balcony
-from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups
+from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups, verify_facemaps_for_object
 
 
 class Balcony:
     @classmethod
     def build(cls, context, prop):
+        verify_facemaps_for_object(context.object)
         me = get_edit_mesh()
         bm = bmesh.from_edit_mesh(me)
         faces = [face for face in bm.faces if face.select]

--- a/core/door/door.py
+++ b/core/door/door.py
@@ -1,12 +1,13 @@
 import bmesh
 
 from .door_types import create_door
-from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups
+from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups, verify_facemaps_for_object
 
 
 class Door:
     @classmethod
-    def build(cls, props):
+    def build(cls, context, props):
+        verify_facemaps_for_object(context.object)
         me = get_edit_mesh()
         bm = bmesh.from_edit_mesh(me)
         faces = [face for face in bm.faces if face.select]

--- a/core/door/door_ops.py
+++ b/core/door/door_ops.py
@@ -19,7 +19,7 @@ class BTOOLS_OT_add_door(bpy.types.Operator):
 
     def execute(self, context):
         self.props.init(get_selected_face_dimensions(context))
-        return Door.build(self.props)
+        return Door.build(context, self.props)
 
     def draw(self, context):
         self.props.draw(context, self.layout)

--- a/core/multigroup/multigroup.py
+++ b/core/multigroup/multigroup.py
@@ -1,12 +1,13 @@
 import bmesh
 
 from .multigroup_types import create_multigroup
-from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups
+from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups, verify_facemaps_for_object
 
 
 class Multigroup:
     @classmethod
-    def build(cls, props):
+    def build(cls, context, props):
+        verify_facemaps_for_object(context.object)
         me = get_edit_mesh()
         bm = bmesh.from_edit_mesh(me)
         faces = [face for face in bm.faces if face.select]

--- a/core/multigroup/multigroup_ops.py
+++ b/core/multigroup/multigroup_ops.py
@@ -19,7 +19,7 @@ class BTOOLS_OT_add_multigroup(bpy.types.Operator):
 
     def execute(self, context):
         self.props.init(get_selected_face_dimensions(context))
-        return Multigroup.build(self.props)
+        return Multigroup.build(context, self.props)
 
     def draw(self, context):
         self.props.draw(context, self.layout)

--- a/core/roof/roof.py
+++ b/core/roof/roof.py
@@ -1,12 +1,13 @@
 import bmesh
 
 from .roof_types import create_roof
-from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups
+from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups, verify_facemaps_for_object
 
 
 class Roof:
     @classmethod
     def build(cls, context, props):
+        verify_facemaps_for_object(context.object)
         me = get_edit_mesh()
         bm = bmesh.from_edit_mesh(me)
         faces = [f for f in bm.faces if f.select]

--- a/core/stairs/stairs.py
+++ b/core/stairs/stairs.py
@@ -1,16 +1,17 @@
 import bmesh
 
 from .stairs_types import create_stairs
-from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups
+from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups, verify_facemaps_for_object
 
 
 class Stairs:
     @classmethod
     def build(cls, context, prop):
+        verify_facemaps_for_object(context.object)
         me = get_edit_mesh()
         bm = bmesh.from_edit_mesh(me)
         faces = [f for f in bm.faces if f.select]
-
+    
         if cls.validate(faces):
             cls.add_stairs_facemaps()
             if create_stairs(bm, faces, prop):

--- a/core/window/window.py
+++ b/core/window/window.py
@@ -1,11 +1,12 @@
 import bmesh
 from .window_types import create_window
-from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups
+from ...utils import get_edit_mesh, FaceMap, add_facemap_for_groups, verify_facemaps_for_object
 
 
 class Window:
     @classmethod
     def build(cls, context, prop):
+        verify_facemaps_for_object(context.object)
         me = get_edit_mesh()
         bm = bmesh.from_edit_mesh(me)
         faces = [face for face in bm.faces if face.select]


### PR DESCRIPTION
compatibility of Building Tools with any kind of Mesh. For example, it should be able to add window to a face of default cube (any mesh not generated by building tools).