### PR TITLE
Only show relevant multigroup options

### DIFF
--- a/core/multigroup/multigroup_props.py
+++ b/core/multigroup/multigroup_props.py
@@ -104,8 +104,9 @@ class MultigroupProperty(bpy.types.PropertyGroup):
         col = box.column(align=True)
         col.prop(self, "count")
 
-        col = box.column(align=True)
-        col.prop(self, "double_door")
+        if str(self.components).find("d") != -1:
+            col = box.column(align=True)
+            col.prop(self, "double_door")
 
         box = layout.box()
         col = box.column(align=True)

--- a/core/multigroup/multigroup_props.py
+++ b/core/multigroup/multigroup_props.py
@@ -88,7 +88,9 @@ class MultigroupProperty(bpy.types.PropertyGroup):
     def draw(self, context, layout):
         box = layout.box()
         self.size_offset.draw(context, box)
-        box.prop(self, "window_height")
+        
+        if str(self.components).find("w") != -1:
+            box.prop(self, "window_height")
 
         box = layout.box()
         col = box.column(align=True)


### PR DESCRIPTION
Showing options that don't have any effect both complicates stuff unnecarely and takes space so I did the following small changed:
- Don't show double door option when there are no doors
- Don't show window height option whne there are no windows

All other options affect both