### PR TITLE
Proper error when no components are chosen for multigroup

### DIFF
--- a/core/multigroup/multigroup_types.py
+++ b/core/multigroup/multigroup_types.py
@@ -30,6 +30,11 @@ def create_multigroup(bm, faces, prop):
     """ Create multigroup from face selection
     """
 
+    # Prevent error when there are no components
+    if len(str(prop.components)) == 0:
+        popup_message("No components are chosen", "No Components Error")
+        return False
+
     for face in faces:
         if not valid_ngon(face):
             popup_message("Multigroup creation not supported for non-rectangular n-gon!", "Ngon Error")


### PR DESCRIPTION
Currently it creates an error and tells you to look in the log. So instead of that it now gives a proper error instead of trying to do invalid operations. A multigroup without components are useless so I could make it so that it changed to the default value (dw) instead of giving the error but I feel like I want to ask you @ranjian0 first. You really should have a discord... would be much better for discussion!

Imo the tool should have it's own errors instead of some error due to invalid operations etc if the values aren't correct