### PR TITLE
Fix misplaced stairs properly

### DIFF
--- a/core/balcony/balcony_props.py
+++ b/core/balcony/balcony_props.py
@@ -33,11 +33,9 @@ class BalconyProperty(bpy.types.PropertyGroup):
 
     def init(self, wall_dimensions):
         self["wall_dimensions"] = wall_dimensions
-        start_y = -((wall_dimensions[1] / 2) - (self.slab_height / 2))
         self.size_offset.init(
             self["wall_dimensions"],
             default_size=(1.0, 1.0),
-            default_offset=(0.0, start_y),
             restricted=False,
         )
 

--- a/core/balcony/balcony_types.py
+++ b/core/balcony/balcony_types.py
@@ -86,7 +86,7 @@ def create_balcony_split(bm, face, prop):
     xyz = local_xyz(face)
     width = min(calc_face_dimensions(face)[0], prop.size_offset.size.x)
     size = Vector((width, prop.slab_height))
-    f = create_face(bm, size, prop.size_offset.offset, xyz)
+    f = create_face(bm, size, prop.size_offset.offset + Vector((0, -(calc_face_dimensions(face)[1] - prop.slab_height) / 2)), xyz)
     bmesh.ops.translate(
         bm, verts=f.verts, vec=face.calc_center_bounds() - face.normal*prop.depth_offset
     )

--- a/core/stairs/stairs_props.py
+++ b/core/stairs/stairs_props.py
@@ -77,11 +77,9 @@ class StairsProperty(bpy.types.PropertyGroup):
 
     def init(self, wall_dimensions):
         self["wall_dimensions"] = wall_dimensions
-        start_y = -((wall_dimensions[1] / 2) - (self.step_height / 2))
         self.size_offset.init(
             (self["wall_dimensions"][0], 0.0),
             default_size=(1.0, 0.0),
-            default_offset=(0.0, start_y),
             restricted=False,
         )
         self.rail.init(self.step_width, self.step_count)

--- a/core/stairs/stairs_types.py
+++ b/core/stairs/stairs_types.py
@@ -21,6 +21,7 @@ from ...utils import (
     add_faces_to_map,
     filter_parallel_edges,
     subdivide_face_vertically,
+    calc_face_dimensions,
 )
 
 from ..railing.railing import create_railing
@@ -170,7 +171,7 @@ def create_stairs_split(bm, face, prop):
     """
     xyz = local_xyz(face)
     size = Vector((prop.size_offset.size.x, prop.step_height))
-    f = create_face(bm, size, prop.size_offset.offset, xyz)
+    f = create_face(bm, size, prop.size_offset.offset - Vector((0, (calc_face_dimensions(face)[1]/2) - prop.step_height * (prop.step_count + 0.5))), xyz)
     bmesh.ops.translate(
         bm, verts=f.verts, vec=face.calc_center_bounds() - face.normal*prop.depth_offset
     )


### PR DESCRIPTION
This makes the stairs always generate at the bottom of the face, regardless of the face height, stair count, stair height etc so they always start from the bottom like you'd exspect. You can still make them generate lower of higher by changing the y-offset. This makes the default y-offset 0 again. I see absolutely no disadvantages to this approach as it's easier and more intuitive to use but let me know if you have any thoughts anyways!

![image](https://user-images.githubusercontent.com/19669673/84773237-6a576600-afdc-11ea-8430-2e7d7d3d03fb.png)

EDIT: This works for creating them on slabs as well :D

Fixes #111 (again)

EDIT 2: Also changed balconies so that the systems are consistent