### PR TITLE
Clamp circle window resolution to prevent error

### DIFF
--- a/core/window/window_props.py
+++ b/core/window/window_props.py
@@ -53,7 +53,7 @@ class WindowProperty(bpy.types.PropertyGroup):
 
     resolution: IntProperty(
         name="Resolution",
-        min=1,
+        min=3,
         max=128,
         default=20,
         description="Number of segements for the circle",


### PR DESCRIPTION
1 creates error and 2 does the same as 3 so now 3 is the min value